### PR TITLE
feat: support gnome 48

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "uuid": "trainfi@altonss.github.io",
   "name": "TrainFi",
   "description": "Display current train trip metadata when connected to onboard Wi-Fi.\nCurrently only supports SNCF TGV INOUI.\n\nFetches trip data from wifi.sncf",
-  "shell-version": ["45", "46", "47"],
+  "shell-version": ["45", "46", "47", "48"],
   "url": "https://github.com/altonss/trainfi",
   "version": 0.1
 }


### PR DESCRIPTION
Hey

I'm currently in the TGV, running gnome 48 on Fedora 42.

I just added gnome shell 48 to the supported version and extensions is working as intended. Thank you for your invaluable work.